### PR TITLE
new: added lsp_diagnostics to enable LSP diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The default configuration is as follows, you can override it with your own setti
 ```lua
 require('sonicpi').setup({
   server_dir = "", -- It will try to find the SonicPi server
+  lsp_diagnostics = false -- enable LSP diagnostics
   mappings = {
     { 'n', '<leader>s', require('sonicpi.remote').stop, default_mapping_opts },
     { 'i', '<M-s>', require('sonicpi.remote').stop, default_mapping_opts },

--- a/lua/sonicpi/init.lua
+++ b/lua/sonicpi/init.lua
@@ -118,6 +118,7 @@ M.setup = function(opts)
 
   local options = require('sonicpi.opts')
   options.server_dir = vim.trim(server_dir)
+  options.lsp_diagnostics = opts.lsp_diagnostics
 
   M.setup_cmp()
   M.setup_treesitter()
@@ -131,9 +132,10 @@ M.lsp_on_init = function(client, opts)
   end
 
   if client.name == 'solargraph' and vim.api.nvim_buf_get_option(0, 'filetype') == 'sonicpi' then
+    local diagnostics = (opts and opts.lsp_diagnostics) or require('sonicpi.opts').lsp_diagnostics
     local cfg = client.config.settings.solargraph
     client.config.settings.single_file_support = true
-    cfg.diagnostics = false
+    cfg.dagnostics = diagnostics
     cfg.reporters = { 'typecheck', 'update_errors' }
 
     cfg.include = cfg.include or {}

--- a/lua/sonicpi/opts.lua
+++ b/lua/sonicpi/opts.lua
@@ -3,6 +3,7 @@ local default_mapping_opts = { noremap = true, silent = true, buffer = 0 }
 
 return {
   server_dir = '',
+  lsp_diagnostics = false,
   cmp_source = {
     keywords = {
       synths = {},


### PR DESCRIPTION
This patch adds the option `lsp_diagnostics`   (defaults to  `false`  to keep the original behavior) to allow users to enable all LSP diagnostics.  