### PR TITLE
Fix broken import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use({
     require('sonicpi').setup()
   end,
   requires = {¬
-    'hrdh7th/nvim-cmp',
+    'hrsh7th/nvim-cmp',
     'kyazdani42/nvim-web-devicons'
   }
 })


### PR DESCRIPTION
Updated the `requires` parameter with the correct `nvim-cmp` repository. (https://github.com/hrsh7th/nvim-cmp)